### PR TITLE
Add base CircleCI configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@ all: decider
 decider:
 	@docker build -f ./Dockerfile -t $(DOCKER_IMAGE) .
 
-
 start: decider
 	@docker run \
 		--name oam-server-decider \

--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
 # OpenAerialMap Server: Decider component
 
+[![Circle CI](https://circleci.com/gh/hotosm/oam-server-decider/tree/master.svg?style=svg)](https://circleci.com/gh/hotosm/oam-server-decider/tree/master)
+[![Docker Repository on Quay.io](https://quay.io/repository/hotosm/oam-server-decider/status "Docker Repository on Quay.io")](https://quay.io/repository/hotosm/oam-server-decider)
+
 The Decider component of OAM Server is a [swfr](http://github.com/stamen/swfr) SWF decider that processes OAM tiling workflows.
 
 ## Usage
 
 The main avenue for developing against the OpenAerialMap (OAM) server is via Docker. To get started, ensure that you have a [working Docker environment](https://docs.docker.com/machine/), with version `>=1.7`. In addition, all interactions with Docker and NPM are wrapped within a `Makefile`.
 
-In order to build this image, use the `activities` target:
+In order to build this image, use the `decider` target:
 
 ```bash
 $ make decider
@@ -28,5 +31,5 @@ CONTAINER ID        IMAGE                          COMMAND             CREATED  
 b1d7b15d6863        oam/server-decider:latest   "npm start"         19 seconds ago      Up 16 seconds       0.0.0.0:8000->8000/tcp   oam-server-decider
 ```
 
-**Note**: For the `start` target, contents within the `activities` directory gets mounted inside of the container via a volume to ensure that the latest code changes are being tested.
+**Note**: For the `start` target, contents within the `decider` directory gets mounted inside of the container via a volume to ensure that the latest code changes are being tested.
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,23 @@
+machine:
+  services:
+    - docker
+
+dependencies:
+  override:
+    - docker login -e . -p ${QUAY_PASSWORD} -u ${QUAY_USER} quay.io
+
+test:
+  pre:
+    - docker build -t quay.io/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}:${CIRCLE_SHA1:0:7} .
+  override:
+    - /bin/true
+
+deployment:
+  latest:
+    branch: master
+    commands:
+      - docker push quay.io/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}:${CIRCLE_SHA1:0:7}
+  release:
+    tag: /[0-9]+(\.[0-9]+)*/
+    commands:
+      - docker push quay.io/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}:$(git tag -l --contains HEAD)


### PR DESCRIPTION
Currently, CircleCI isn't actually running any tests (only `/bin/true`), but that can easily be updated in `circle.yml`.

More interesting is that CircleCI is setup to build and publish container images (to Quay) for all merges into `master` using the first seven characters of the Git commit as the container image's tag. Git tag pushes also produce container images, which are identified by the same version number of the tag.

See also:
- https://circleci.com/gh/hotosm/oam-server-decider
- https://quay.io/repository/hotosm/oam-server-decider

Related to https://github.com/hotosm/oam-server/issues/12
